### PR TITLE
Make read/writes more pretty.

### DIFF
--- a/Buffer/Makefile
+++ b/Buffer/Makefile
@@ -38,6 +38,7 @@ experiment:
 	./test
 
 publish:
+	-rm project4.tar.gz
 	tar -czf project4.tar.gz *.c *.h *.py Makefile readme.txt
 
 


### PR DESCRIPTION
The only behavior changes are 
(1) reading less than `len` bytes if `count < len` for read syscall
(2) sometimes restoring semaphores during error handling.